### PR TITLE
[BE]refactor: 멤버조회시 applicant에 boardId와 img만 반환되게 수정

### DIFF
--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/server" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/server" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/server" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/server/src/main/java/com/party/auth/fliter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/party/auth/fliter/JwtAuthenticationFilter.java
@@ -67,6 +67,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+
         Member member = (Member) authResult.getPrincipal();
 
         String accessToken = delegateAccessToken(member);

--- a/server/src/main/java/com/party/member/dto/MemberApplicantResponseDto.java
+++ b/server/src/main/java/com/party/member/dto/MemberApplicantResponseDto.java
@@ -1,0 +1,11 @@
+package com.party.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberApplicantResponseDto {
+    private long boardId;
+    private String imgUrl;
+}

--- a/server/src/main/java/com/party/member/dto/MemberResponseDto.java
+++ b/server/src/main/java/com/party/member/dto/MemberResponseDto.java
@@ -19,7 +19,7 @@ public class MemberResponseDto {
     private String gender;
     private String introduce;
     private String imageUrl;
-    private List<ApplicantResponseDto> applicants = new ArrayList<>();
+    private List<MemberApplicantResponseDto> applicants = new ArrayList<>();
     private List<MemberBoardLikeResponseDto> boardLikes = new ArrayList<>();
     private long follower;
     private long following;

--- a/server/src/main/java/com/party/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/party/member/mapper/MemberMapper.java
@@ -1,5 +1,6 @@
 package com.party.member.mapper;
 
+import com.party.board.entity.Applicant;
 import com.party.board.mapper.ApplicantMapper;
 import com.party.boardlike.entity.BoardLike;
 import com.party.member.dto.*;
@@ -26,4 +27,8 @@ public interface MemberMapper {
     @Mapping(target = "boardId", source = "board.id")
     @Mapping(target = "imgUrl", source = "board.imageUrl")
     MemberBoardLikeResponseDto boardLikeToMemberBoardLikeResponseDto(BoardLike boardLike);
+
+    @Mapping(target = "imgUrl", source = "boardImageUrl")
+    @Mapping(target = "boardId", source = "board.id")
+    MemberApplicantResponseDto applicantToMemberApplicantResponseDto(Applicant applicant);
 }


### PR DESCRIPTION
[BE]refactor: 멤버조회시 applicant에 boardId와 img만 반환되게 수정

applicant 필드를 다 보내주면 비효율적이고 정보를 확인하기 힘든거 같아서 필요해보이는 정보만 보내게 수정하였습니다.

빌드테스트 완료