### PR TITLE
[BE]docs: 카카오 로그인 redirect URL 변경

### DIFF
--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -28,8 +28,7 @@ spring:
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: http://localhost:3000
-#            redirect-uri: http://celebee-bucket.s3-website.ap-northeast-2.amazonaws.com
+            redirect-uri: http://celebee-bucket.s3-website.ap-northeast-2.amazonaws.com
             authorization-grant-type: authorization_code
             client-authentication-method: POST
             client-name: Kakao

--- a/server/src/main/resources/application-server.yml
+++ b/server/src/main/resources/application-server.yml
@@ -30,7 +30,7 @@ spring:
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: http://localhost:3000
+            redirect-uri: http://celebee-bucket.s3-website.ap-northeast-2.amazonaws.com
             authorization-grant-type: authorization_code
             client-authentication-method: POST
             client-name: Kakao


### PR DESCRIPTION
[BE]docs: 카카오 로그인 redirect URL 변경

카카오 로그인 관련 redirect-uri 변경했습니다
aws서버에서 되려면 배포주소로 설정이 되어야 한다고 찾아서.. 일단 수정했습니다.

참고:
https://devtalk.kakao.com/t/aws-ec2-ubuntu-spring-boot/130447/4