### PR TITLE
[BE]feat: usernamepassword 인증시 refreshToken발행과 동시에 해당 토큰을 Member 테이블에 저장시키기 완료

### DIFF
--- a/server/src/main/java/com/party/auth/config/SecurityConfiguration.java
+++ b/server/src/main/java/com/party/auth/config/SecurityConfiguration.java
@@ -7,6 +7,7 @@ import com.party.auth.util.CustomAuthorityUtils;
 import com.party.member.entity.Member;
 import com.party.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -33,7 +34,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfiguration {
     private final JwtTokenizer jwtTokenizer;
     private final CustomAuthorityUtils authorityUtils;
-    private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -96,7 +97,7 @@ public class SecurityConfiguration {
         @Override
         public void configure(HttpSecurity builder) throws Exception {
             AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
-            JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenizer, authenticationManager, memberRepository);
+            JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenizer, authenticationManager, applicationEventPublisher);
             jwtAuthenticationFilter.setFilterProcessesUrl("/members/login");
 
             JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, authorityUtils);

--- a/server/src/main/java/com/party/auth/event/RefreshSaveEvent.java
+++ b/server/src/main/java/com/party/auth/event/RefreshSaveEvent.java
@@ -1,0 +1,16 @@
+package com.party.auth.event;
+
+import com.party.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshSaveEvent {
+    private Member member;
+    private String refreshToken;
+}

--- a/server/src/main/java/com/party/auth/event/RefreshSaveEventListener.java
+++ b/server/src/main/java/com/party/auth/event/RefreshSaveEventListener.java
@@ -1,0 +1,31 @@
+package com.party.auth.event;
+
+import com.party.member.entity.Member;
+import com.party.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Slf4j
+@EnableAsync
+@Transactional
+@RequiredArgsConstructor
+public class RefreshSaveEventListener {
+    private final MemberRepository memberRepository;
+
+    @Async
+    @EventListener
+    public void handleRefreshSaveEvent(RefreshSaveEvent event) {
+        Member member = event.getMember();
+        String rft = event.getRefreshToken();
+        log.info("memberrepository 활성여부" + memberRepository);
+        System.out.println("여긴 이벤트 리스너 rft 값" + rft);
+        System.out.println("여긴 이벤트 리스너 member id" + member.getId().toString());
+        memberRepository.updateRefreshToken(member.getId(), rft);
+    }
+}

--- a/server/src/main/java/com/party/auth/fliter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/party/auth/fliter/JwtAuthenticationFilter.java
@@ -2,11 +2,13 @@ package com.party.auth.fliter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.party.auth.dto.LoginDto;
+import com.party.auth.event.RefreshSaveEvent;
 import com.party.auth.token.JwtTokenizer;
 import com.party.member.entity.Member;
 import com.party.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -26,7 +28,7 @@ import java.util.Map;
 public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter{
     private final JwtTokenizer jwtTokenizer;
     private final AuthenticationManager authenticationManager;
-    private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     private String delegateAccessToken(Member member) {
         Map<String, Object> claims = new HashMap<>();
@@ -79,6 +81,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 //        // 멤버 레코드의 refreshToken만 업데이트 해주는 쿼리를
 //        // 사용해서 Member의 refreshToken을 refresh 칼럼에 저장
 //        memberRepository.updateRefreshToken(member.getId(), refreshToken);
+        System.out.println("여긴 필터단계" + refreshToken);
+        applicationEventPublisher.publishEvent(new RefreshSaveEvent(member, refreshToken));
 
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("Refresh", "Bearer " + refreshToken);

--- a/server/src/main/java/com/party/member/entity/Member.java
+++ b/server/src/main/java/com/party/member/entity/Member.java
@@ -40,7 +40,7 @@ public class Member {
     private String imageUrl;
 
     // 작성하다 보니까 필요가 없어졌음
-//    private String refreshToken;
+    private String refreshToken;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     @JsonManagedReference

--- a/server/src/main/java/com/party/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/party/member/repository/MemberRepository.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
-//    @Modifying
-//    @Query("update Member m set m.refreshToken = :refreshToken where m.id = :id")
-//    void updateRefreshToken(@Param("id") Long id, @Param("refreshToken") String refreshToken);
+    @Modifying
+    @Query("update Member m set m.refreshToken = :refreshToken where m.id = :id")
+    void updateRefreshToken(@Param("id") Long id, @Param("refreshToken") String refreshToken);
     void deleteByEmail(String email);
 }


### PR DESCRIPTION
비동기로 처리 -> 추후 변경가능

카카오 로그인시에도 refreshToken을 저장하게 하고

refresh토큰 재발급 시에 1차적으로 DB의 rft과 동일한지 검증하는 코드 작성예정

Member 엔티티에 컬럼추가 있습니다