### PR TITLE
[Fe] 자기소개 편집 및 프로필 이미지 편집 기능 구현완료

### DIFF
--- a/client/src/components/Button.js
+++ b/client/src/components/Button.js
@@ -23,14 +23,7 @@ const StyleButton = styled.button`
     margin-bottom: 10px;
   }
 
-  &.Button-membership {
-    font-weight: 700;
-    padding: 2px 10px;
-    margin-left: 20px;
-    background-color: rgba(246, 246, 246, 0);
-  }
-
-  &.Button-newCard {
+  &.Button-based {
     width: 110px;
     height: 42px;
     font-weight: 700;
@@ -49,38 +42,63 @@ const StyleButton = styled.button`
     margin-left: 20px;
   }
 
-  &.Button-like,
-  &.Button-participations {
-    width: 150px;
-    height: 50px;
-    background-color: ${(props) => props.color || 'white'};
+  &.Button-like {
+    width: 180px;
+    height: 60px;
+    background-color: #ff6ac6;
     border: none;
     border-radius: 20px;
     cursor: pointer;
     padding: 0px;
     margin-left: 30px;
     margin-right: 30px;
+    color: white;
+    font-size: 1.2rem;
+  }
+  &.Button-participations {
+    width: 180px;
+    height: 60px;
+    background-color: #ffa472;
+    border: none;
+    border-radius: 20px;
+    cursor: pointer;
+    padding: 0px;
+    margin-left: 30px;
+    margin-right: 30px;
+    color: white;
+    font-size: 1.2rem;
+  }
+
+  &.Button-text {
+    background-color: rgba(246, 246, 246, 0);
+    border: none;
+    color: white;
+    border-radius: 0;
+    font-weight: 600;
+    font-size: 1.2rem;
+    text-align: right;
+    position: absolute;
+    bottom: 1px;
+    right: 10px;
+    cursor: pointer;
   }
 `;
 
-const Button = ({ type, text, onClick, color }) => {
+const Button = ({ type, text, onClick }) => {
   const btnType = [
-    'membership',
+    'based',
     'newCard',
     'notification',
     'like',
     'participations',
     'login',
+    'text',
   ].includes(type)
     ? type
     : 'default';
 
   return (
-    <StyleButton
-      className={`Button-${btnType}`}
-      color={color}
-      onClick={onClick}
-    >
+    <StyleButton className={`Button-${btnType}`} onClick={onClick}>
       {text}
     </StyleButton>
   );
@@ -92,8 +110,7 @@ Button.defaultProps = {
 
 Button.propTypes = {
   type: PropTypes.string.isRequired,
-  text: PropTypes.string.isRequired,
-  color: PropTypes.string.isRequired,
+  text: PropTypes.object.isRequired,
   onClick: PropTypes.func.isRequired,
 };
 

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -80,7 +80,7 @@ const Header = () => {
         {isLogin ? (
           <ButtonBox>
             <Link to="/boards/new-boards">
-              <Button type="newCard" text="New Card!" />
+              <Button type="based" text="New Card!" />
             </Link>
             {isNew ? (
               <Button
@@ -96,18 +96,15 @@ const Header = () => {
             <Link to={`/members/${memberId}`} className="user-info">
               <FaRegUserCircle className="user-info-icon" />
             </Link>
-            <Button type="membership" text="Logout" onClick={handleLogout} />
+            <Button type="based" text="Logout" onClick={handleLogout} />
           </ButtonBox>
         ) : (
           <ButtonBox>
-            <Link to="/boards/new-boards">
-              <Button type="membership" text="New Card" />
-            </Link>
             <Link to="/members/login">
-              <Button type="membership" text="Log In" />
+              <Button type="based" text="Log In" />
             </Link>
             <Link to="/members">
-              <Button type="membership" text="Sign Up" />
+              <Button type="based" text="Sign Up" />
             </Link>
           </ButtonBox>
         )}

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -53,9 +53,9 @@ const ButtonBox = styled.div`
 
 const Header = () => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const isLogin = useSelector((state) => state.auth.isLogin);
   const isNew = useSelector((state) => state.new.isNew);
-  const dispatch = useDispatch();
   const memberId = useSelector((state) => state.user.memberId);
 
   const handleNewStatus = () => {

--- a/client/src/components/LikeIt.js
+++ b/client/src/components/LikeIt.js
@@ -1,27 +1,22 @@
 import { styled } from 'styled-components';
 import PropTypes from 'prop-types';
 
-const DibsOnPost = styled.div`
+const ContentList = styled.ul`
   display: flex;
-  flex-direction: column;
-`;
-
-const ContentRow = styled.li`
   list-style-type: none;
-  display: flex;
+  width: 70vw;
   flex-wrap: wrap;
   margin-top: 20px;
-  margin-bottom: 30px;
 `;
 
-const ContentItem = styled.div`
+const ContentItem = styled.li`
   width: 16em;
   height: 16em;
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-left: 45px;
-  margin-right: 45px;
+  margin-left: 30px;
+  margin-right: 30px;
   margin-bottom: 20px;
 
   img {
@@ -36,17 +31,15 @@ const LikeIt = ({ user }) => {
   }
 
   return (
-    <DibsOnPost>
-      <ContentRow>
-        {user.boardLikes.map((el, boardId) => {
-          return (
-            <ContentItem key={boardId}>
-              <img src={el.imgUrl} alt="찜한 목록" />
-            </ContentItem>
-          );
-        })}
-      </ContentRow>
-    </DibsOnPost>
+    <ContentList>
+      {user.boardLikes.map((el, boardId) => {
+        return (
+          <ContentItem key={boardId}>
+            <img src={el.imgUrl} alt="찜한 목록" />
+          </ContentItem>
+        );
+      })}
+    </ContentList>
   );
 };
 

--- a/client/src/components/Modal.js
+++ b/client/src/components/Modal.js
@@ -1,0 +1,40 @@
+import { styled } from 'styled-components';
+import PropTypes from 'prop-types';
+
+const ModalContainer = styled.div`
+  width: 550px;
+  height: 350px;
+  background-color: rgba(255, 255, 255, 0.95);
+  border: 1px black solid;
+  position: absolute;
+  z-index: 999;
+  top: 125px;
+  left: 110px;
+  padding-top: 30px;
+  display: flex;
+  justify-content: center;
+
+  .modal-content {
+    button {
+      background-color: rgba(255, 255, 255, 0.95);
+      border: 0;
+    }
+  }
+`;
+
+const Modal = ({ closeModal, children }) => {
+  return (
+    <ModalContainer onClick={closeModal}>
+      <div className="modal-content">
+        <button onClick={(e) => e.stopPropagation()}>{children}</button>
+      </div>
+    </ModalContainer>
+  );
+};
+
+Modal.propTypes = {
+  closeModal: PropTypes.func.isRequired,
+  children: PropTypes.object.isRequired,
+};
+
+export default Modal;

--- a/client/src/components/MyPageTab.js
+++ b/client/src/components/MyPageTab.js
@@ -8,6 +8,7 @@ const MyTabContainer = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 75vw;
   margin-top: 50px;
 `;
 
@@ -18,7 +19,7 @@ const MyTabBtn = styled.div`
 
 const TabContentContainer = styled.div`
   margin-top: 40px;
-  width: 75vw;
+  width: 70vw;
 `;
 const MyPageTab = ({ activetab, handleTabClick, user }) => {
   return (
@@ -26,7 +27,6 @@ const MyPageTab = ({ activetab, handleTabClick, user }) => {
       <MyTabBtn>
         <Button
           text="Like It"
-          color="hotpink"
           type="like"
           label="tab1"
           onClick={() => {
@@ -35,7 +35,6 @@ const MyPageTab = ({ activetab, handleTabClick, user }) => {
         />
         <Button
           text="Participation"
-          color="orange"
           type="participations"
           label="tab2"
           onClick={() => {
@@ -52,7 +51,7 @@ const MyPageTab = ({ activetab, handleTabClick, user }) => {
 };
 
 MyPageTab.propTypes = {
-  activetab: PropTypes.func.isRequired,
+  activetab: PropTypes.string.isRequired,
   handleTabClick: PropTypes.func.isRequired,
   user: PropTypes.object.isRequired,
 };

--- a/client/src/components/Participations.js
+++ b/client/src/components/Participations.js
@@ -1,27 +1,22 @@
 import { styled } from 'styled-components';
 import PropTypes from 'prop-types';
 
-const MyPartyPost = styled.div`
+const ContentList = styled.ul`
   display: flex;
-  flex-direction: column;
-`;
-
-const ContentRow = styled.li`
   list-style-type: none;
-  display: flex;
+  width: 70vw;
   flex-wrap: wrap;
   margin-top: 20px;
-  margin-bottom: 30px;
 `;
 
-const ContentItem = styled.div`
+const ContentItem = styled.li`
   width: 16em;
   height: 16em;
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-left: 45px;
-  margin-right: 45px;
+  margin-left: 30px;
+  margin-right: 30px;
   margin-bottom: 20px;
 
   img {
@@ -32,17 +27,15 @@ const ContentItem = styled.div`
 
 const Participations = ({ user }) => {
   return (
-    <MyPartyPost>
-      <ContentRow>
-        {user.applicants.map((el, boardId) => {
-          return (
-            <ContentItem key={boardId}>
-              <img src={el.imgUrl} alt="my-party-list" />
-            </ContentItem>
-          );
-        })}
-      </ContentRow>
-    </MyPartyPost>
+    <ContentList>
+      {user.applicants.map((el, boardId) => {
+        return (
+          <ContentItem key={boardId}>
+            <img src={el.imgUrl} alt="my-party-list" />
+          </ContentItem>
+        );
+      })}
+    </ContentList>
   );
 };
 

--- a/client/src/components/Profile.js
+++ b/client/src/components/Profile.js
@@ -2,12 +2,17 @@ import { styled } from 'styled-components';
 import { Icon } from '@iconify/react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import Button from './Button';
+import Modal from './Modal';
 
 const ProfileContainer = styled.div`
   width: 76vw;
   height: 100%;
   display: flex;
   margin-bottom: 2em;
+  position: relative;
 `;
 
 const AvatarContainer = styled.div`
@@ -28,6 +33,41 @@ const AvatarContainer = styled.div`
     width: 100px;
     height: 100px;
     color: #d99bff;
+  }
+
+  .profile-img {
+    width: 150px;
+    border-radius: 50%;
+  }
+`;
+
+const TitleBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  h3 {
+    font-size: 1.6rem;
+    font-weight: bolder;
+  }
+`;
+
+const ImgBox = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 30px;
+
+  button {
+    border: 0;
+    background-color: rgba(255, 255, 255, 0.95);
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+  img {
+    width: 150px;
+    height: 150px;
+    border-radius: 50%;
   }
 `;
 
@@ -57,62 +97,205 @@ const UserInfoContainer = styled.div`
   flex-direction: column;
   font-size: 1.3rem;
   text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+`;
 
-  .info-box {
+const InfoBox = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: 5px;
+  margin-bottom: 15px;
+
+  b,
+  p {
+    padding-left: 10px;
+    padding-right: 10px;
+    margin: 0;
+  }
+
+  span {
     display: flex;
+    justify-content: center;
     align-items: center;
-    margin-left: 5px;
-    margin-bottom: 15px;
-
-    b,
-    p {
-      padding-left: 10px;
-      padding-right: 10px;
-      margin: 0;
-    }
-
-    span {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    }
   }
 
   .gender-sign {
     width: 30px;
     height: 30px;
   }
+`;
 
-  .introduction-box {
-    border: 1px solid black;
-    width: 50vw;
-    height: 4.8em;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-bottom: 0;
-    margin-top: 10px;
-    margin-left: 15px;
+const IntorBox = styled.div`
+  border: 1px solid black;
+  width: 50vw;
+  height: 4.8em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 10px;
+  margin-left: 15px;
+  position: relative;
+
+  input {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 49.89vw;
+    height: 100%;
+    margin-top: 5px;
+    font-size: 1.2rem;
+    padding: 10px;
   }
 `;
 
-const Profile = ({ user }) => {
-  const { email, gender, introduce, nickname, follower, following } = user;
+const BtnBox = styled.div`
+  position: relative;
+`;
+
+const Profile = ({ user, setUser }) => {
+  const { email, gender, introduce, nickname, follower, following, imageUrl } =
+    user;
   const isLogin = useSelector((state) => state.auth.isLogin);
+  const [isIntroEditing, setIsIntroEditing] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isImages, setisImages] = useState([]);
+
+  /* 함수에서 공통으로 사용할 데이터 */
+  const token = localStorage.getItem('jwtToken');
+  const memberId = useSelector((state) => state.user.memberId);
+  const patchData = {
+    introduce,
+  };
+
+  /* 수정할 프로필 이미지 받아오기 */
+  const getProfileImg = async () => {
+    try {
+      const response = await axios.get(
+        'http://3.39.76.109:8080/members/images',
+      );
+      setisImages(response.data);
+    } catch (error) {
+      console.error('실패', error);
+    }
+  };
+
+  useEffect(() => {
+    getProfileImg();
+  }, []);
+
+  /* 프로필 이미지 수정 - 모달 */
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleImageSelect = async (e) => {
+    if (token) {
+      try {
+        const imageUrl = e.target.currentSrc; // 클릭한 이미지의 URL 가져오기
+
+        // 서버에 이미지 업로드 요청을 보냅니다.
+        const response = await axios.patch(
+          `http://3.39.76.109:8080/members/${memberId}`,
+          { imageUrl: imageUrl }, // 이미지 URL을 보냅니다.
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        );
+
+        // 서버에서 업로드된 이미지의 URL을 받아옵니다.
+        const newImageUrl = response.data.imageUrl;
+
+        // 이미지 URL을 state에 업데이트합니다.
+        setUser({ ...user, imageUrl: newImageUrl }); // imageUrl 업데이트
+
+        // 모달을 닫습니다.
+        closeModal();
+
+        console.log('프로필 이미지 업로드 성공');
+      } catch (error) {
+        console.error('프로필 이미지 업로드 실패', error);
+      }
+    }
+  };
+
+  /* 자기 소개글 수정 */
+  const handleIntroEditClick = () => {
+    setIsIntroEditing(true);
+  };
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setUser((user) => ({
+      ...user,
+      [name]: value,
+    }));
+  };
+
+  const handleIntroChange = async () => {
+    if (token) {
+      try {
+        const response = await axios.patch(
+          `http://3.39.76.109:8080/members/${memberId}`,
+          patchData,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        );
+        setIsIntroEditing(false);
+        console.log('PATCH 요청 성공!', response.data);
+      } catch (error) {
+        console.log('PATCH 요청 실패!', error);
+      }
+    } else {
+      console.error('토큰이 없으므로 PATCH 요청을 보낼 수 없습니다.');
+    }
+  };
 
   return (
     <ProfileContainer>
-      <AvatarContainer>
-        <Icon icon="mingcute:ghost-line" className="avatar-img" />
-        {isLogin ? (
-          <EditIconBox>
+      {isLogin ? (
+        <AvatarContainer>
+          <EditIconBox onClick={openModal}>
             <Icon className="edit-icon" icon="uil:edit" color="#9669f7" />
           </EditIconBox>
-        ) : null}
-      </AvatarContainer>
+          {imageUrl ? (
+            <img src={imageUrl} alt="프로필 이미지" className="profile-img" />
+          ) : (
+            <Icon icon="mingcute:ghost-line" className="avatar-img" />
+          )}
+        </AvatarContainer>
+      ) : (
+        <AvatarContainer>
+          <Icon icon="mingcute:ghost-line" className="avatar-img" />
+        </AvatarContainer>
+      )}
+      {isModalOpen ? (
+        <Modal closeModal={closeModal}>
+          <TitleBox>
+            <h3>Select</h3>
+            <br />
+            <h3>Yore Profile Image</h3>
+          </TitleBox>
+          <ImgBox>
+            {isImages.map((el, idx) => (
+              <button key={idx} onClick={handleImageSelect}>
+                <img src={el} alt={`el ${idx}`} />
+              </button>
+            ))}
+          </ImgBox>
+        </Modal>
+      ) : null}
+
       <UserInfoContainer>
         {/* 로그인 정보의 닉네임과 이메일이 표시됨 */}
-        <div className="info-box">
+        <InfoBox>
           <b className="nickname">{nickname}</b>
           <p className="address-box">{email}</p>
           {/* 로그인 정보의 젠더 정보에 따라 다른 아이콘이 렌더링 */}
@@ -123,20 +306,49 @@ const Profile = ({ user }) => {
               <Icon icon="emojione-v1:girl" className="gender-sign" />
             )}
           </span>
-        </div>
+        </InfoBox>
         {/* 로그인 정보의 follower, follwing이 표시됨 */}
-        <div className="info-box">
+        <InfoBox>
           <b className="follow-info">Follower</b>
           {/* 숫자는 일천단위 K, 일만단위 M 으로 표시 */}
           <p className="follow-info">{follower}</p>
           <b className="follow-info">Following</b>
           {/* 숫자는 일천단위 K, 일만단위 M 으로 표시 */}
           <p className="follow-info">{following}</p>
-        </div>
+        </InfoBox>
         {/* 유저 정보의 자기소개내용 표시 */}
-        <div className="introduction-box">
-          <p>{introduce}</p>
-        </div>
+        {isIntroEditing ? (
+          <div>
+            <IntorBox>
+              <div>
+                <input
+                  name="introduce"
+                  value={introduce}
+                  onChange={handleInputChange}
+                  placeholder="자기소개를 입력해주세요."
+                />
+              </div>
+            </IntorBox>
+            <BtnBox>
+              <Button type="text" text="Save" onClick={handleIntroChange} />
+            </BtnBox>
+          </div>
+        ) : (
+          <div>
+            <IntorBox className="introduction-box">
+              <p>{introduce}</p>
+            </IntorBox>
+            {isLogin ? (
+              <BtnBox>
+                <Button
+                  type="text"
+                  text="Edit"
+                  onClick={handleIntroEditClick}
+                />
+              </BtnBox>
+            ) : null}
+          </div>
+        )}
       </UserInfoContainer>
     </ProfileContainer>
   );
@@ -144,5 +356,7 @@ const Profile = ({ user }) => {
 
 Profile.propTypes = {
   user: PropTypes.object.isRequired,
+  setUser: PropTypes.func.isRequired,
 };
+
 export default Profile;

--- a/client/src/components/Profile.js
+++ b/client/src/components/Profile.js
@@ -20,7 +20,7 @@ const AvatarContainer = styled.div`
   height: 150px;
   border: 1px solid rgba(245, 245, 245, 1);
   border-radius: 50%;
-  background-color: #f5f5f5;
+  background-color: rgba(256, 256, 256, 0);
   box-shadow: 0px 3px 7px 1px rgba(105, 105, 105, 0.4);
   display: flex;
   justify-content: center;
@@ -37,6 +37,7 @@ const AvatarContainer = styled.div`
 
   .profile-img {
     width: 150px;
+    height: 150px;
     border-radius: 50%;
   }
 `;
@@ -64,6 +65,7 @@ const ImgBox = styled.div`
     margin-left: 10px;
     margin-right: 10px;
   }
+
   img {
     width: 150px;
     height: 150px;
@@ -152,8 +154,7 @@ const BtnBox = styled.div`
 `;
 
 const Profile = ({ user, setUser }) => {
-  const { email, gender, introduce, nickname, follower, following, imageUrl } =
-    user;
+  const { email, gender, introduce, nickname, follower, following } = user;
   const isLogin = useSelector((state) => state.auth.isLogin);
   const [isIntroEditing, setIsIntroEditing] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -199,7 +200,7 @@ const Profile = ({ user, setUser }) => {
         // 서버에 이미지 업로드 요청을 보냅니다.
         const response = await axios.patch(
           `http://3.39.76.109:8080/members/${memberId}`,
-          { imageUrl: imageUrl }, // 이미지 URL을 보냅니다.
+          { imageUrl }, // 이미지 URL을 보냅니다.
           {
             headers: {
               Authorization: `Bearer ${token}`,
@@ -265,14 +266,21 @@ const Profile = ({ user, setUser }) => {
           <EditIconBox onClick={openModal}>
             <Icon className="edit-icon" icon="uil:edit" color="#9669f7" />
           </EditIconBox>
-          {imageUrl ? (
-            <img src={imageUrl} alt="프로필 이미지" className="profile-img" />
+          {user.imageUrl ? (
+            <img
+              src={user.imageUrl}
+              alt="프로필 이미지"
+              className="profile-img"
+            />
           ) : (
             <Icon icon="mingcute:ghost-line" className="avatar-img" />
           )}
         </AvatarContainer>
       ) : (
         <AvatarContainer>
+          <EditIconBox onClick={openModal}>
+            <Icon className="edit-icon" icon="uil:edit" color="#9669f7" />
+          </EditIconBox>
           <Icon icon="mingcute:ghost-line" className="avatar-img" />
         </AvatarContainer>
       )}

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -40,7 +40,17 @@ const MyPage = () => {
         `http://3.39.76.109:8080/members/${memberId}`,
       );
       const myInfo = response.data;
-      setUser(myInfo);
+      const userData = {
+        id: myInfo.id,
+        nickname: myInfo.nickname,
+        email: myInfo.email,
+        gender: myInfo.gender,
+        introduce: myInfo.introduce,
+        imageUrl: myInfo.imageUrl,
+        follower: myInfo.follower,
+        following: myInfo.following,
+      };
+      setUser(userData);
     } catch (error) {
       console.error(error);
     }

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -17,7 +17,19 @@ const MyPageSection = styled.section`
 
 //레이아웃 부터 잡기!
 const MyPage = () => {
-  const [user, setUser] = useState({});
+  const [user, setUser] = useState({
+    id: 0,
+    nickname: '',
+    email: '',
+    gender: '',
+    introduce: '',
+    imageUrl: '',
+    follower: 0,
+    following: 0,
+    applicants: [{ boardId: 0, imgUrl: '' }],
+    boardLikes: [{ boardId: 0, imgUrl: '' }],
+  });
+
   const [activetab, setActiveTab] = useState('tab1');
 
   const memberId = useSelector((state) => state.user.memberId);
@@ -35,7 +47,10 @@ const MyPage = () => {
   };
 
   useEffect(() => {
-    fetchMyInfo();
+    // user 데이터가 비어있을 때만 API 호출
+    if (!user.id) {
+      fetchMyInfo();
+    }
   }, []);
 
   const handleTabClick = (tabId) => {
@@ -44,7 +59,7 @@ const MyPage = () => {
 
   return (
     <MyPageSection>
-      <Profile user={user} />
+      <Profile user={user} setUser={setUser} />
       <MyPageTab
         activetab={activetab}
         handleTabClick={handleTabClick}

--- a/client/src/redux/reducers.js
+++ b/client/src/redux/reducers.js
@@ -13,7 +13,7 @@ const authReducer = (state = initialState, action) => {
       return {
         ...state,
         isLogin: true,
-        token: action.payload.token,
+        token: action.payload,
       };
     case 'LOGOUT':
       return {


### PR DESCRIPTION
1. 자기소개 편집
  - edit 버튼을 누르면 자기소개 박스가 인풋 박스로 변하여 새로운 내용을 작성할 수 있음
  - 작성완료 후, save 버튼 누르면 작성한 자기소개가 유저데이터에 저장되어 렌더링됨
 
2. 프로필 이미지 편집
  - 기본 프로필 이미지 하단에 편집 아이콘을 누르면 모달창이 생성됨.
  - 해당 모달창에서 제공하는 이미지중 하나를 누르면 모달창이 닫히면서, 프로필 이미지가 수정됨
  - 해당 프로필 이미지는 클릭할때, 유저데이터에 저장되어 다시 로그인햇을 때도, 수정한 이미지가 렌더링

3. 보완점
 - 모임 페이지에서 호스트 아이콘 클릭 시 해당 호스트 유저 페이지가 렌더링 될 수 있도록 작성 필요