### PR TITLE
[BE]feat: 마이페이지 좋아요, 참여 모임 최신순정렬 설정

### DIFF
--- a/server/src/main/java/com/party/member/controller/MemberController.java
+++ b/server/src/main/java/com/party/member/controller/MemberController.java
@@ -87,8 +87,22 @@ public class MemberController {
     public ResponseEntity myPage() {
         int loginMemberId = (int) memberService.extractMemberInfo().get("id");
         Member member = memberService.findMember(loginMemberId);
+        MemberResponseDto responseDto = mapper.memberToMemberResponseDto(member);
+        // applicants 정렬
+        responseDto.setApplicants(
+                responseDto.getApplicants().stream()
+                        .sorted(Comparator.comparing(MemberApplicantResponseDto::getBoardId).reversed())
+                        .collect(Collectors.toList())
+        );
 
-        return new ResponseEntity(mapper.memberToMemberResponseDto(member), HttpStatus.OK);
+        // boardLikes 정렬
+        responseDto.setBoardLikes(
+                responseDto.getBoardLikes().stream()
+                        .sorted(Comparator.comparing(MemberBoardLikeResponseDto::getBoardId).reversed())
+                        .collect(Collectors.toList())
+        );
+
+        return new ResponseEntity(responseDto, HttpStatus.OK);
     }
 
     // 파라미터의 회원 id와 토큰의 id를 비교해서 동일한 회원이면 update실행


### PR DESCRIPTION
[BE]feat: 마이페이지 좋아요, 참여 모임 최신순정렬 설정

정확히 말하면 작성일자는 등록되어있지 않아서 Id값의 역순으로 정렬되게 했습니다 결과는 같게 나올거 같아서