### PR TITLE
[BE]feat: 닉네임 중복발생시 클라이언트에 중복된 닉네임 예외 메시지 발송, 자기소개글 20자 이내로 작성, 마이페이지에서 상태와 작성된 순서에 따라 조회되게 변경

### DIFF
--- a/server/src/main/java/com/party/exception/ExceptionCode.java
+++ b/server/src/main/java/com/party/exception/ExceptionCode.java
@@ -17,6 +17,7 @@ public enum ExceptionCode {
     UNAUTHORIZED_FOLLOW(400,"You don't have permission"),
     UNAUTHORIZED_ACCESS(400,"You don't have permission"),
     FOLLOW_NOT_FOUND(400,"Follow not found"),
+    NICKNAME_EXIST(409, "Nickname exist"),
     REFRESHTOKEN_IS_NOT_VERIFIED(402, "Refresh Token is not verified");
 
 

--- a/server/src/main/java/com/party/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/party/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.party.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessLogicException.class)
+    public ResponseEntity handleBusinessLogicException(BusinessLogicException e) {
+        return new ResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/server/src/main/java/com/party/member/dto/MemberApplicantResponseDto.java
+++ b/server/src/main/java/com/party/member/dto/MemberApplicantResponseDto.java
@@ -1,5 +1,6 @@
 package com.party.member.dto;
 
+import com.party.board.entity.Board;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,4 +9,5 @@ import lombok.Setter;
 public class MemberApplicantResponseDto {
     private long boardId;
     private String imgUrl;
+    private Board.BoardStatus boardStatus;
 }

--- a/server/src/main/java/com/party/member/dto/MemberBoardLikeResponseDto.java
+++ b/server/src/main/java/com/party/member/dto/MemberBoardLikeResponseDto.java
@@ -9,4 +9,5 @@ import lombok.Setter;
 public class MemberBoardLikeResponseDto {
     private Long boardId;
     private String imgUrl;
+    private Board.BoardStatus boardStatus;
 }

--- a/server/src/main/java/com/party/member/dto/MemberPatchDto.java
+++ b/server/src/main/java/com/party/member/dto/MemberPatchDto.java
@@ -3,9 +3,12 @@ package com.party.member.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.Pattern;
+
 @Getter
 @Setter
 public class MemberPatchDto {
+    @Pattern(regexp = "^.{1,20}$", message = "소개글은 20자 이내로 입력해주세요.")
     private String introduce;
     private String imageUrl;
 

--- a/server/src/main/java/com/party/member/entity/Member.java
+++ b/server/src/main/java/com/party/member/entity/Member.java
@@ -10,6 +10,7 @@ import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.Email;
+import javax.validation.constraints.Pattern;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/server/src/main/java/com/party/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/party/member/mapper/MemberMapper.java
@@ -26,9 +26,11 @@ public interface MemberMapper {
 
     @Mapping(target = "boardId", source = "board.id")
     @Mapping(target = "imgUrl", source = "board.imageUrl")
+    @Mapping(target = "boardStatus", source = "board.status")
     MemberBoardLikeResponseDto boardLikeToMemberBoardLikeResponseDto(BoardLike boardLike);
 
     @Mapping(target = "imgUrl", source = "boardImageUrl")
     @Mapping(target = "boardId", source = "board.id")
+    @Mapping(target = "boardStatus", source = "board.status")
     MemberApplicantResponseDto applicantToMemberApplicantResponseDto(Applicant applicant);
 }

--- a/server/src/main/java/com/party/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/party/member/repository/MemberRepository.java
@@ -21,4 +21,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("select m.refreshToken from Member m where m.id = :id")
     Optional<String> findRefreshTokenById(Long id);
+
+    Optional<Member> findByNickname(String nickname);
 }

--- a/server/src/main/java/com/party/member/service/MemberService.java
+++ b/server/src/main/java/com/party/member/service/MemberService.java
@@ -33,6 +33,9 @@ public class MemberService {
 
     public Member createMember(Member member) {
         verifyExistsEmail(member.getEmail());
+        if(memberRepository.findByNickname(member.getNickname()).isPresent()) {
+            throw new BusinessLogicException(ExceptionCode.NICKNAME_EXIST);
+        }
         String encryptedPassword = passwordEncoder.encode(member.getPassword());
         member.setPassword(encryptedPassword);
 


### PR DESCRIPTION
닉네임 중복시 Nickname exist 예외 메시지 발송 -> 카카오로 중복되면 발송 안 됩니다.. 나중에 Security 리팩터링 하면서 바꿔야할거 같아요

자기소개글 수정시 20자 이상으로 못하게 막았습니다

마이페이지에서 좋아요와 참여한 모임 조회시 상태와 작성순서에 따라 정렬되어 보여지게 수정했습니다