### PR TITLE
[FE] 카카오 로그인, 게시물에서 유저페이지 이동 관련, 모달 닫기 버튼 이슈 등

### DIFF
--- a/client/src/components/LikeIt.js
+++ b/client/src/components/LikeIt.js
@@ -26,7 +26,6 @@ const ContentItem = styled.li`
 `;
 
 const LikeIt = ({ myData, memberData, handleMovingBoard }) => {
-  console.log(memberData, myData);
   return (
     <ContentList>
       {memberData

--- a/client/src/components/Modal.js
+++ b/client/src/components/Modal.js
@@ -20,13 +20,26 @@ const ModalContainer = styled.div`
       border: 0;
     }
   }
+
+  .close-btn {
+    font-size: 3rem;
+    display: flex;
+    position: absolute;
+    top: 14px;
+    right: 20px;
+  }
 `;
 
 const Modal = ({ closeModal, children }) => {
   return (
     <ModalContainer onClick={closeModal}>
       <div className="modal-content">
-        <button onClick={(e) => e.stopPropagation()}>{children}</button>
+        <button onClick={(e) => e.stopPropagation()}>
+          <button onClick={closeModal} className="close-btn">
+            &times;
+          </button>
+          <span>{children}</span>
+        </button>
       </div>
     </ModalContainer>
   );

--- a/client/src/components/Participations.js
+++ b/client/src/components/Participations.js
@@ -26,8 +26,6 @@ const ContentItem = styled.li`
 `;
 
 const Participations = ({ myData, memberData, handleMovingBoard }) => {
-  console.log(memberData, myData);
-
   return (
     <ContentList>
       {memberData

--- a/client/src/pages/InvitePage.js
+++ b/client/src/pages/InvitePage.js
@@ -135,13 +135,22 @@ function InvitePage() {
   const hostPageClick = () => {
     const hostId = eventData.member.id;
     localStorage.setItem('clickedUserId', hostId);
-    navigate(`/members/${hostId}`);
+    if (hostId && memberId) {
+      navigate(`/members/me`);
+    } else {
+      navigate(`/members/${hostId}`);
+    }
   };
 
   // 참여자 페이지 이동
   const handleParticipantImageClick = (memberId) => {
     localStorage.setItem('clickedUserId', memberId);
-    navigate(`/members/${memberId}`); // 유저 페이지로 이동
+    const clickedUserId = localStorage.getItem('clickedUserId');
+    if (clickedUserId && memberId) {
+      navigate(`/members/me`);
+    } else {
+      navigate(`/members/${memberId}`); // 유저 페이지로 이동
+    }
   };
 
   const numberWithCommas = (x) => {

--- a/client/src/pages/KakaoRedirect.js
+++ b/client/src/pages/KakaoRedirect.js
@@ -25,6 +25,7 @@ export default function Kakao() {
             const token = response.headers.authorization;
             const myId = response.headers.memberid;
             localStorage.setItem('jwtToken', token);
+            localStorage.setItem('myId', myId);
             console.log('성공했니');
             dispatch(login(token));
             dispatch(fetchMyData(myId));

--- a/client/src/pages/UserPage.js
+++ b/client/src/pages/UserPage.js
@@ -34,7 +34,6 @@ const UserPage = () => {
   const [activetab, setActiveTab] = useState('tab1');
 
   const userId = localStorage.getItem('clickedUserId');
-  console.log(userId);
   useEffect(() => {
     if (!memberData.id) {
       const fetchUserInfo = async () => {
@@ -43,7 +42,6 @@ const UserPage = () => {
             `http://3.39.76.109:8080/members/${userId}`,
           );
           const memberInfo = response.data;
-          console.log(memberInfo);
           const userData = {
             id: memberInfo.id,
             nickname: memberInfo.nickname,


### PR DESCRIPTION
- 모달 닫기 버튼 생성
- 카카오 로그인 시 응답헤더의 memberid를 로컬스토리지에 저장하는 코드 추가
- 로그인 유저의 경우 게시물 내에서 멤버 이미지 클릭 시 마이페이지로 이동할 수 있도록 수정