### PR TITLE
[BE]feat: 닉네임 중복시 409, 이메일중복시 410 상태코드를 보내주게 변경

### DIFF
--- a/server/src/main/java/com/party/auth/service/OAuthService.java
+++ b/server/src/main/java/com/party/auth/service/OAuthService.java
@@ -159,6 +159,10 @@ public class OAuthService {
     }
 
     private Member saveMember(MemberProfile memberProfile) {
+        if (memberRepository.findByEmail(memberProfile.getEmail()).isPresent()) {
+            throw new BusinessLogicException(ExceptionCode.MEMBER_EXIST);
+        }
+
         Member member = Member.createMember(
                 memberProfile.getEmail(),
                 "oauthUser",

--- a/server/src/main/java/com/party/exception/ExceptionCode.java
+++ b/server/src/main/java/com/party/exception/ExceptionCode.java
@@ -3,7 +3,7 @@ package com.party.exception;
 import lombok.Getter;
 
 public enum ExceptionCode {
-    MEMBER_EXIST(409, "Member exists"),
+    MEMBER_EXIST(410, "Member exists"),
     MEMBER_NOT_FOUND(404, "Member not found"),
     BOARD_NOT_FOUND(405, "board not found"),
     NOT_ALLOW_PARTICIPATE(405, "unable to participate"),

--- a/server/src/main/java/com/party/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/party/exception/GlobalExceptionHandler.java
@@ -10,6 +10,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessLogicException.class)
     public ResponseEntity handleBusinessLogicException(BusinessLogicException e) {
-        return new ResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity(e.getMessage(), HttpStatus.valueOf(e.getExceptionCode().getStatus()));
     }
 }

--- a/server/src/main/java/com/party/member/service/MemberService.java
+++ b/server/src/main/java/com/party/member/service/MemberService.java
@@ -36,6 +36,7 @@ public class MemberService {
         if(memberRepository.findByNickname(member.getNickname()).isPresent()) {
             throw new BusinessLogicException(ExceptionCode.NICKNAME_EXIST);
         }
+
         String encryptedPassword = passwordEncoder.encode(member.getPassword());
         member.setPassword(encryptedPassword);
 


### PR DESCRIPTION
닉네임 중복시 409, 이메일중복시 410 상태코드를 보내주게하였습니다 상태메시지도 같이 바디로 갑니다